### PR TITLE
chore: add pre-commit hooks and pre-commit ci

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,5 @@
+---
+skip_list:
+  - yaml
+  - schema[meta]
+  - risky-octal

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,45 @@
+---
+default_stages: [commit]
+
+repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.6
+    hooks:
+      - id: prettier
+        always_run: true
+        additional_dependencies:
+          - prettier
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: mixed-line-ending
+      - id: fix-byte-order-marker
+      - id: check-added-large-files
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v2.42.1
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages:
+          - post-commit
+          - push
+
+  - repo: https://github.com/ansible/ansible-lint
+    rev: v6.14.4
+    hooks:
+      - id: ansible-lint
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.30.0
+    hooks:
+      - id: yamllint
+        files: \.(yaml|yml)$
+        types: [file, yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,12 @@
 ---
 default_stages: [commit]
 
+ci:
+  autoupdate_commit_msg: "chore: pre-commit autoupdate"
+  autoupdate_schedule: monthly
+  autofix_commit_msg: |
+    chore: auto fixes from pre-commit.com hooks
+
 repos:
   - repo: meta
     hooks:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,11 @@
+---
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1 # prettier compatiblity
+  line-length:
+    max: 120
+    level: warning
+    allow-non-breakable-words: true
+    allow-non-breakable-inline-mappings: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/kmezynski/ansible-role-dotfiles/master.svg)](https://results.pre-commit.ci/latest/github/kmezynski/ansible-role-dotfiles/master)
+
 # Ansible Role: Dotfiles


### PR DESCRIPTION
- chore(pre-commit): add initial configuration file
- ci(pre-commit): add pre-commit ci configuration
- chore(pre-commit): add yamllint configuration file
- chore(pre-commit): add ansible-lint configuration file
- chore: add gitignore for virtualenvironments
- docs: add pre-commit ci badge